### PR TITLE
Update installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  </h1>
 
 <pre align="center">
-  $ yarn create react-app my-app -- --scripts-version reason-scripts
+  $ yarn create react-app my-app --scripts-version reason-scripts
 </pre>
 
 Reason Scripts provides a JS-like development environment for developing web apps with the


### PR DESCRIPTION
```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```