### PR TITLE
Update installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To create a new app using Reason and React, run:
 
 ```
 $ npm install -g bs-platform
-$ yarn create react-app <app-name> -- --scripts-version reason-scripts
+$ yarn create react-app <app-name> --scripts-version reason-scripts
 $ cd <app-name>
 $ yarn start
 ```


### PR DESCRIPTION
I missed one more place
```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```