### PR TITLE
Update readme with advide on file path naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ let logo : string = [%bs.raw {|require('./logo.svg')|}];
 <summary><b>My app won't compile on a fresh install</b></summary>
 
 Try running `npm install` in your project directory. This helps refresh missing dependencies sometimes.
+
+If this still does not work, make sure your file path does not include any spaces.
 </details></p>
 
 


### PR DESCRIPTION
When trying to get a `reason-react` app to compile locally, I started to have failed builds. This did not happen when creating a basic reason starter project with `bsb -init my-first-app -theme basic-reason`. In that project everything compiled correctly. After some time, I noticed in the logs the compiler was not reading my file path correctly so I changed it from having a space in-between to no space: `Native Projects` to `NativeProjects`. Now everything works as expected. It may not be apparent at first glance that this is the issue the user is running into. There must be some difference between how a basic `reason` project is compiled in comparison to a `reason-react` project. Either way, I think it would be nice to warn the user there is this caveat in how you build your file path to a `reason-react` project.