### PR TITLE
add bs files glob matcher

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -27,6 +27,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}',
       '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}',
+      '<rootDir>/src/**/?(*{.,_})+(spec|test)?(.bs).{js,jsx,mjs}',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',


### PR DESCRIPTION
The current glob `<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}` does not match any of these: `App_test.js`, `App_test.bs.js`, `App.test.bs.js` 

The added glob ('<rootDir>/src/**/?(*{.,_})+(spec|test)?(.bs).{js,jsx,mjs}') matches all of them