### PR TITLE
WIP jest config bs-loader

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,5 @@
+parser: flow
+semi: true
+singleQuote: true
+trailingComma: es5
+bracketSpacing: true

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -27,6 +27,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}',
       '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}',
+      '<rootDir>/src/**/__tests__/**/*.{re,ml}',
+      '<rootDir>/src/**/*_test.{re,ml}',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',
@@ -38,6 +40,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^(?!.*\\.(js|jsx|mjs|css|json)$)': resolve(
         'config/jest/fileTransform.js'
       ),
+      '^.+\\.(re|ml)$': isEjecting
+        ? '<rootDir>/node_modules/bs-loader'
+        : 'bs-loader',
     },
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
@@ -51,6 +56,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
       'jsx',
       'node',
       'mjs',
+      're',
+      'ml',
     ],
   };
   if (rootDir) {


### PR DESCRIPTION
added `bs-loader` config per https://github.com/reasonml-community/bs-loader

Tests are loaded, but not correctly:
```
Your test suite must contain at least one test.
```

Additionally `bs-loader` has the following notice:
This library is in maintanence mode. Instead of using bs-loader we recommend using bsb' new in-source builds in conjunction with .bs.js extensions: